### PR TITLE
Fix regex backtrack explosion in long multiline column

### DIFF
--- a/lib/redshift_csv_file.rb
+++ b/lib/redshift_csv_file.rb
@@ -79,7 +79,7 @@ class RedshiftCsvFile
     def scan_column
       s = @s
       s.skip(/[ \t]+/)
-      until column = s.scan(/"(?:\\.|[^"\\]+)*"/m)
+      until column = s.scan(/"(?:\\.|[^"\\])*"/m)
         fill_buffer or return nil
         return nil if s.eos?
         if s.rest_size > MAX_COLUMN_LENGTH

--- a/test/test_redshift_csv_file.rb
+++ b/test/test_redshift_csv_file.rb
@@ -27,6 +27,9 @@ class TestRedshiftCsvFile < Test::Unit::TestCase
     assert_equal ['981179', '2017-01-07', '6', '852', 'show', '{"page"=>"4"}', '1', '1'],
       parse_row(%Q("981179","2017-01-07","6","852","show","{\\"page\\"=>\\"4\\"}","1","1"\n))
 
+    assert_equal ['x,x', "longdatalongdatalongdatalongdatalongdatalongdatalongdata\ntrailingdata\n", 'z"z', 'a\\a'],
+      parse_row(%Q("x\\,x","longdatalongdatalongdatalongdatalongdatalongdatalongdata\\\ntrailingdata\\\n","z\\"z","a\\\\a"\n))
+
     assert_raises RedshiftCsvFile::MalformedCSVException do
       parse_row(%Q("xxx,"yyy"))
     end


### PR DESCRIPTION
ref: https://github.com/bricolages/redshift-connector-data_file/pull/7

I guess this regression occurred when this CSV parser was separated off redshift-connector-data_file.
